### PR TITLE
update link to Simplfier KT2.0 "project root"

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -63,7 +63,7 @@
 
 ## Useful Links
 
-* [Simplifier Profiles](https://simplifier.net/Koppeltaalv2.0/\~resources?fhirVersion=R4)
+* [Simplifier Profiles](https://simplifier.net/Koppeltaalv2.0/)
 * [FHIR Docs](https://www.hl7.org/fhir/documentation.html)
 * [HTI documentation](https://github.com/GIDSOpenStandaarden/GIDS-HTI-Protocol/blob/master/HTI.md)
 * [GitHub](https://github.com/Koppeltaal/)


### PR DESCRIPTION
This link points you at the "top" of the KT2 project in Simplifier. Now that more info is to be found there, it is better IMHO to land there.